### PR TITLE
Change print format to JSON

### DIFF
--- a/do_like_javac/tools/jprint.py
+++ b/do_like_javac/tools/jprint.py
@@ -1,11 +1,13 @@
-import pprint
+import json
 
 argparser = None
 
 def run(args, javac_commands, jars):
-  pp = pprint.PrettyPrinter(indent=2)
-  for jc in javac_commands:
-    pp.pprint(jc)
-    javac_switches = jc['javac_switches']
-#  print("Target JARs (experimental):")
-#  pp.pprint(jars)
+  print (json.dumps(
+    {
+      "javac_commands": javac_commands,
+      "jars": jars
+    },
+    indent = 2,
+    separators = (',', ': ')
+  ));

--- a/do_like_javac/tools/jprint.py
+++ b/do_like_javac/tools/jprint.py
@@ -7,5 +7,5 @@ def run(args, javac_commands, jars):
   for jc in javac_commands:
     pp.pprint(jc)
     javac_switches = jc['javac_switches']
-  print("Target JARs (experimental):")
-  pp.pprint(jars)
+#  print("Target JARs (experimental):")
+#  pp.pprint(jars)


### PR DESCRIPTION
Changing the print format to json makes it so much easier to parse the output. 
