### PR TITLE
add cfArgs option in infer.py

### DIFF
--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -17,6 +17,9 @@ infer_group.add_argument('-m', '--mode', metavar='<mode>',
 infer_group.add_argument('-solverArgs', '--solverArgs', metavar='<solverArgs>',
                         action='store',default='backEndType=maxsatbackend.MaxSat',
                         help='arguments for solver')
+infer_group.add_argument('-cfArgs', '--cfArgs', metavar='<cfArgs>',
+                        action='store',default='',
+                        help='arguments for checker framework')
 
 def run(args, javac_commands, jars):
     # the dist directory if CFI.
@@ -36,6 +39,7 @@ def run(args, javac_commands, jars):
         cmd = CFI_command + ['-classpath', cp,
                              'checkers.inference.InferenceLauncher',
                              '--solverArgs', args.solverArgs,
+                             '--cfArgs', args.cfArgs,
                              '--checker', args.checker,
                              '--solver', args.solver,
                              '--mode', args.mode,


### PR DESCRIPTION
Add `cfArgs` option in infer.py.
- purpose: let ontology or any other third party infer type systems could pass arguments for checker-framework through shell command. 
- reason: some big projects ontology running on (e.g. ode4j) needs to increase the default value of `DEFAULT_CACHE_SIZE` in Checker Framework. Thus we need this `cfArgs` option to enable ontology could pass Checker Framework specific arguments to increase this cache size. This option is also could serve for general purpose of passing CF specific arguments.
