### PR TITLE
append system classpath in infer mode

### DIFF
--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -36,6 +36,9 @@ def run(args, javac_commands, jars):
              ':' + os.path.join(CFI_dist, 'plume.jar') + \
              ':' + os.path.join(CFI_dist, 'checker-framework-inference.jar')
 
+        if 'CLASSPATH' in os.environ:
+            cp += ':' + os.environ['CLASSPATH']
+
         cmd = CFI_command + ['-classpath', cp,
                              'checkers.inference.InferenceLauncher',
                              '--solverArgs', args.solverArgs,


### PR DESCRIPTION
in infer.py, try to append system classpath if it is not empty.

Currently by this way we could pass the classpath of ontology to do-like-javac as ontology is a type system outside of both checker-framework and checker-framework-inference.
