### PR TITLE
Dyntrace and graphtools updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ That's it. No other external dependencies for the core `do-like-javac` scripts.
 
 Of course, you will also need to have installed:
 
-* The analysis tool(s) you want to run. 
+* The analysis tool(s) you want to run.
 * Any build dependencies of the project you're analyzing.
 
 `do-like-javac` was built and tested on Mac OS X and GNU/Linux. It probably also
@@ -89,14 +89,29 @@ The print tool (`dljc -t print`) will pretty-print the detected `javac` commands
 Bixie
 -----
 
-The Bixie tool will run your project through [Bixie](http://sri-csl.github.io/bixie/). You must specify a path to the Bixie jar file with the `--bixie-jar` argument, e.g.
+The Bixie tool will run your project through [Bixie](http://sri-csl.github.io/bixie/). You will need to provide a library directory containing bixie.jar using the `--lib` option.
 
-    dljc --bixie-jar path/to/bixie.jar -t bixie -- mvn compile
+    dljc --lib path/to/libs/ -t bixie -- mvn compile
 
-Randoop
--------
+Dyntrace
+---------
 
-No special arguments are required to run [Randoop](https://randoop.github.io/randoop/). In fact, Randoop itself is not a prequisite. Invoking `dljc -t randoop` will automatically download any necessary dependencies and create a script (or scripts) named something like "run\_randoop\_0001.sh", which you can then run to run randoop on your code.
+The Dyntrace tool will run your project through Randoop to generate tests, then run those tests with Daikon/Chicory. You will need to provide a library directory with the following jars using the `--lib` option:
+
+* randoop.jar
+* junit-4.12.jar
+* daikon.jar
+* hamcrest-core-1.3.jar
+
+    dljc --lib path/to/libs/ -t dyntrace -- mvn compile
+
+You may also choose to invoke the Randoop and Daikon/Chicory phases separately (though the Chicory phase depends on the output of the Randoop phase), e.g.
+
+    dljc --lib path/to/libs/ -t randoop -- mvn compile
+
+or
+
+    dljc --lib path/to/libs/ -t chicory -- mvn compile
 
 LICENSE
 =======

--- a/do_like_javac/arg.py
+++ b/do_like_javac/arg.py
@@ -43,6 +43,10 @@ base_group.add_argument('-c', '--checker', metavar='<checker>',
                         action='store',default='NullnessChecker',
                         help='A checker to check (for checker/inference tools)')
 
+base_group.add_argument('-l', '--lib', metavar='<lib_dir>',
+                        action='store',dest='lib_dir',
+                        help='Library directory with JARs for tools that need them.')
+
 def split_args_to_parse():
     split_index = len(sys.argv)
     if CMD_MARKER in sys.argv:

--- a/do_like_javac/cache.py
+++ b/do_like_javac/cache.py
@@ -8,7 +8,7 @@ def retrieve(cmd, args, capturer):
     with open(cache_file, 'rb') as f:
       return pickle.load(f)
 
-  javac_commands, jars = capturer.gen_instance(cmd).capture()
+  javac_commands, jars = capturer.gen_instance(cmd, args).capture()
   with open(cache_file, 'wb') as f:
     pickle.dump((javac_commands, jars), f)
 

--- a/do_like_javac/cache.py
+++ b/do_like_javac/cache.py
@@ -8,8 +8,8 @@ def retrieve(cmd, args, capturer):
     with open(cache_file, 'rb') as f:
       return pickle.load(f)
 
-  javac_commands, jars = capturer.gen_instance(cmd, args).capture()
+  javac_commands, jars, stats = capturer.gen_instance(cmd, args).capture()
   with open(cache_file, 'wb') as f:
-    pickle.dump((javac_commands, jars), f)
+    pickle.dump((javac_commands, jars, stats), f)
 
-  return javac_commands, jars
+  return javac_commands, jars, stats

--- a/do_like_javac/capture/ant.py
+++ b/do_like_javac/capture/ant.py
@@ -11,12 +11,13 @@ import generic
 
 supported_commands = ['ant']
 
-def gen_instance(cmd):
-    return AntCapture(cmd)
+def gen_instance(cmd, args):
+    return AntCapture(cmd, args)
 
 class AntCapture(generic.GenericCapture):
 
-    def __init__(self, cmd):
+    def __init__(self, cmd, args):
+        super(AntCapture, self).__init__(cmd, args)
         self.build_cmd = ['ant', '-verbose'] + cmd[1:]
 
     def is_interesting(self, content):

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -1,3 +1,4 @@
+import os
 import util
 import zipfile
 
@@ -16,9 +17,10 @@ def get_entry_point(jar):
 
     return {"jar": jar}
 
-class GenericCapture:
-    def __init__(self, cmd):
+class GenericCapture(object):
+    def __init__(self, cmd, args):
         self.build_cmd = cmd
+        self.args = args
 
     def get_javac_commands(self, verbose_output):
         return []
@@ -28,8 +30,14 @@ class GenericCapture:
 
     def capture(self):
         build_output = util.get_build_output(self.build_cmd)
-        javac_commands = self.get_javac_commands(build_output)
-        target_jars = self.get_target_jars(build_output)
+
+        with open(os.path.join(self.args.output_directory, 'build_output.txt'), 'w') as f:
+            f.write(build_output)
+
+        build_lines = build_output.split('\n')
+
+        javac_commands = self.get_javac_commands(build_lines)
+        target_jars = self.get_target_jars(build_lines)
         jars_with_entry_points = map(get_entry_point, target_jars)
         return [javac_commands, jars_with_entry_points]
 

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -81,7 +81,7 @@ class GenericCapture(object):
 
     def record_stats(self, stats, javac_commands, jars):
         stats['source_files'] = sum([len(cmd['java_files']) for cmd in javac_commands])
-        stats['class_files'] = sum([len(cmdtools.get_classes(cmd)) for cmd in javac_commands])
+        stats['class_files'] = sum([len(cmdtools.get_class_files(cmd)) for cmd in javac_commands])
         stats['javac_invocations'] = len(javac_commands)
         stats['built_jars'] = len(jars)
         stats['executable_jars'] = len([jar for jar in jars if 'main' in jar])

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -46,7 +46,7 @@ class GenericCapture(object):
         target_jars = self.get_target_jars(build_lines)
         jars_with_entry_points = map(get_entry_point, target_jars)
 
-        self.record_stats(stats, javac_commands, jars_with_entry_points)
+        self.record_stats(stats, javac_commands, jars, jars_with_entry_points)
 
         return [javac_commands, jars_with_entry_points, stats]
 
@@ -79,8 +79,9 @@ class GenericCapture(object):
 
         return dict(java_files=files, javac_switches=switches)
 
-    def record_stats(self, stats, javac_commands, jars):
+    def record_stats(self, stats, javac_commands, jars, executable_jars):
         stats['source_files'] = sum([len(cmd['java_files']) for cmd in javac_commands])
         stats['class_files'] = sum([len(cmdtools.get_classes(cmd)) for cmd in javac_commands])
         stats['javac_invocations'] = len(javac_commands)
         stats['built_jars'] = len(jars)
+        stats['executable_jars'] = len(executable_jars)

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -1,6 +1,8 @@
 import os
 import util
 import zipfile
+import timeit
+import do_like_javac.tools.common as cmdtools
 
 def is_switch(s):
     return s != None and s.startswith('-')
@@ -29,7 +31,11 @@ class GenericCapture(object):
         return []
 
     def capture(self):
+        stats = {}
+
+        start_time = timeit.default_timer()
         build_output = util.get_build_output(self.build_cmd)
+        stats['build_time'] = timeit.default_timer() - start_time
 
         with open(os.path.join(self.args.output_directory, 'build_output.txt'), 'w') as f:
             f.write(build_output)
@@ -39,7 +45,10 @@ class GenericCapture(object):
         javac_commands = self.get_javac_commands(build_lines)
         target_jars = self.get_target_jars(build_lines)
         jars_with_entry_points = map(get_entry_point, target_jars)
-        return [javac_commands, jars_with_entry_points]
+
+        self.record_stats(stats, javac_commands, jars_with_entry_points)
+
+        return [javac_commands, jars_with_entry_points, stats]
 
     def javac_parse(self, javac_command):
         files = []
@@ -69,3 +78,7 @@ class GenericCapture(object):
                 prev_arg = None
 
         return dict(java_files=files, javac_switches=switches)
+
+    def record_stats(self, stats, javac_commands, jars):
+        stats['source_files'] = sum([len(cmd['java_files']) for cmd in javac_commands])
+        stats['class_files'] = sum([len(cmdtools.get_classes(cmd)) for cmd in javac_commands)

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -46,7 +46,7 @@ class GenericCapture(object):
         target_jars = self.get_target_jars(build_lines)
         jars_with_entry_points = map(get_entry_point, target_jars)
 
-        self.record_stats(stats, javac_commands, jars, jars_with_entry_points)
+        self.record_stats(stats, javac_commands, jars_with_entry_points)
 
         return [javac_commands, jars_with_entry_points, stats]
 
@@ -79,9 +79,9 @@ class GenericCapture(object):
 
         return dict(java_files=files, javac_switches=switches)
 
-    def record_stats(self, stats, javac_commands, jars, executable_jars):
+    def record_stats(self, stats, javac_commands, jars):
         stats['source_files'] = sum([len(cmd['java_files']) for cmd in javac_commands])
         stats['class_files'] = sum([len(cmdtools.get_classes(cmd)) for cmd in javac_commands])
         stats['javac_invocations'] = len(javac_commands)
         stats['built_jars'] = len(jars)
-        stats['executable_jars'] = len(executable_jars)
+        stats['executable_jars'] = len([jar for jar in jars if 'main' in jar])

--- a/do_like_javac/capture/generic.py
+++ b/do_like_javac/capture/generic.py
@@ -81,4 +81,6 @@ class GenericCapture(object):
 
     def record_stats(self, stats, javac_commands, jars):
         stats['source_files'] = sum([len(cmd['java_files']) for cmd in javac_commands])
-        stats['class_files'] = sum([len(cmdtools.get_classes(cmd)) for cmd in javac_commands)
+        stats['class_files'] = sum([len(cmdtools.get_classes(cmd)) for cmd in javac_commands])
+        stats['javac_invocations'] = len(javac_commands)
+        stats['built_jars'] = len(jars)

--- a/do_like_javac/capture/gradle.py
+++ b/do_like_javac/capture/gradle.py
@@ -11,12 +11,12 @@ import generic
 
 supported_commands = ['gradle', 'gradlew']
 
-def gen_instance(cmd):
-    return GradleCapture(cmd)
+def gen_instance(cmd, args):
+    return GradleCapture(cmd, args)
 
 class GradleCapture(generic.GenericCapture):
-
-    def __init__(self, cmd):
+    def __init__(self, cmd, args):
+        super(GradleCapture, self).__init__(cmd, args)
         self.build_cmd = [cmd[0], '--debug'] + cmd[1:]
 
     def get_javac_commands(self, verbose_output):

--- a/do_like_javac/capture/javac.py
+++ b/do_like_javac/capture/javac.py
@@ -11,12 +11,12 @@ import generic
 
 supported_commands = ['javac']
 
-def gen_instance(cmd):
-    return JavaCapture(cmd)
+def gen_instance(cmd, args):
+    return JavaCapture(cmd, args)
 
 class JavaCapture(generic.GenericCapture):
-
-    def __init__(self, cmd):
+    def __init__(self, cmd, args):
+        super(JavaCapture, self).__init__(cmd, args)
         self.build_cmd = cmd
         self.cmd = cmd[1:]
 

--- a/do_like_javac/capture/mvn.py
+++ b/do_like_javac/capture/mvn.py
@@ -12,11 +12,12 @@ import generic
 
 supported_commands = ['mvn']
 
-def gen_instance(cmd):
-    return MavenCapture(cmd)
+def gen_instance(cmd, args):
+    return MavenCapture(cmd, args)
 
 class MavenCapture(generic.GenericCapture):
-    def __init__(self, cmd):
+    def __init__(self, cmd, args):
+        super(MavenCapture, self).__init__(cmd, args)
         self.build_cmd = ['mvn', '-X'] + cmd[1:]
 
     def get_target_jars(self, verbose_output):

--- a/do_like_javac/capture/util.py
+++ b/do_like_javac/capture/util.py
@@ -17,7 +17,7 @@ def get_build_output(build_cmd):
     #  TODO make it return generator to be able to handle large builds
     proc = subprocess.Popen(build_cmd, stdout=subprocess.PIPE, stderr=open(os.devnull, 'w'))
     (verbose_out_chars, _) = proc.communicate()
-    return verbose_out_chars.split('\n')
+    return verbose_out_chars
 
 def run_cmd_ignore_fail(cmd):
     try:

--- a/do_like_javac/command.py
+++ b/do_like_javac/command.py
@@ -3,6 +3,13 @@ import arg
 import log
 import tools
 import cache
+import os,json
+
+def output_json(filename, obj):
+    with open(filename, 'w') as f:
+        f.write(json.dumps(obj,
+                           sort_keys=True,
+                           indent=4))
 
 def main():
     args, cmd, capturer = arg.parse_args()
@@ -13,5 +20,7 @@ def main():
     javac_commands, jars = cache.retrieve(cmd, args, capturer)
 
     log.info('Results: %s', pprint.pformat(javac_commands))
+    output_json(os.path.join(args.output_directory, 'javac.json'), javac_commands)
+    output_json(os.path.join(args.output_directory, 'jars.json'), jars)
 
     tools.run(args, javac_commands, jars)

--- a/do_like_javac/command.py
+++ b/do_like_javac/command.py
@@ -17,10 +17,11 @@ def main():
     log.configure_logging(args.output_directory, args.log_to_stderr)
     log.log_header()
 
-    javac_commands, jars = cache.retrieve(cmd, args, capturer)
+    javac_commands, jars, stats = cache.retrieve(cmd, args, capturer)
 
     log.info('Results: %s', pprint.pformat(javac_commands))
     output_json(os.path.join(args.output_directory, 'javac.json'), javac_commands)
     output_json(os.path.join(args.output_directory, 'jars.json'), jars)
+    output_json(os.path.join(args.output_directory, 'stats.json'), stats)
 
     tools.run(args, javac_commands, jars)

--- a/do_like_javac/tools/__init__.py
+++ b/do_like_javac/tools/__init__.py
@@ -37,5 +37,6 @@ def parse_tools(tools):
   return [tool for tool in tools.split(',') if check_tool(tool)]
 
 def run(args, javac_commands, jars):
-  for tool in parse_tools(args.tool):
-    TOOLS[tool].run(args, javac_commands, jars)
+  if args.tool:
+    for tool in parse_tools(args.tool):
+      TOOLS[tool].run(args, javac_commands, jars)

--- a/do_like_javac/tools/__init__.py
+++ b/do_like_javac/tools/__init__.py
@@ -1,7 +1,9 @@
 import jprint
 import randoop
+import randoop_old
 import bixie
 import graphtools
+import chicory
 import dyntrace
 
 # import soot
@@ -14,8 +16,10 @@ TOOLS = {
   'inference' : infer,
   'print'     : jprint,
   'randoop'   : randoop,
+  'randoop_old': randoop_old,
   'bixie'     : bixie,
   'graphtool' : graphtools,
+  'chicory'   : chicory,
   'dyntrace'  : dyntrace,
 }
 

--- a/do_like_javac/tools/bixie.py
+++ b/do_like_javac/tools/bixie.py
@@ -1,20 +1,12 @@
 import os
-import argparse
 import common
 
-argparser = argparse.ArgumentParser(add_help=False)
-bixie_group = argparser.add_argument_group('bixie arguments')
-
-bixie_group.add_argument('--bixie-jar', metavar='<bixie-jar>',
-                         action='store',default=None, dest='bixie_jar',
-                         help='Path to bixie.jar')
+argparser = None
 
 def run(args, javac_commands, jars):
-  if not args.bixie_jar:
-    print "Could not run bixie tool: missing arg --bixie-jar"
-    return
+  bixie_jar = os.path.join(lib_dir, "bixie.jar")
 
-  bixie_command = ["java", "-jar", args.bixie_jar,
+  bixie_command = ["java", "-jar", bixie_jar,
                     "-html", os.path.join(args.output_directory, 'bixie_report')]
 
   i = 1

--- a/do_like_javac/tools/chicory.py
+++ b/do_like_javac/tools/chicory.py
@@ -8,5 +8,5 @@ def run(args, javac_commands, jars):
   out_dir = os.path.basename(args.output_directory)
 
   for jc in javac_commands:
-    dyntrace.dyntrace(i, jc, out_dir, args.lib_dir, ['randoop'])
+    dyntrace.dyntrace(i, jc, out_dir, args.lib_dir, ['chicory'])
     i = i+1

--- a/do_like_javac/tools/common.py
+++ b/do_like_javac/tools/common.py
@@ -19,15 +19,22 @@ def class_directory(javac_command):
       return switches['d']
   return None
 
-def get_classes(javac_command):
+def get_class_files(javac_command):
   classes = []
   classdir = class_directory(javac_command)
 
   if classdir:
     for root, dirs, files in os.walk(classdir):
-      classes.extend([file for file in files if '.class' in file])
+      classes.extend([os.path.join(root,file) for file in files if '.class' in file])
 
   return classes
+
+def get_classes(javac_command):
+  def class_file_to_class_name(classdir, class_file):
+    class_name.replace(classdir + "/", '').replace('.class','').replace('/','.')
+
+  classdir = class_directory(javac_command)
+  return [class_file_to_class_name(classdir, file) for file in get_class_files(javac_command)]
 
 def source_path(javac_command):
   if 'javac_switches' in javac_command:

--- a/do_like_javac/tools/common.py
+++ b/do_like_javac/tools/common.py
@@ -31,7 +31,7 @@ def get_class_files(javac_command):
 
 def get_classes(javac_command):
   def class_file_to_class_name(classdir, class_file):
-    class_name.replace(classdir + "/", '').replace('.class','').replace('/','.')
+    return class_file.replace(classdir + "/", '').replace('.class','').replace('/','.')
 
   classdir = class_directory(javac_command)
   return [class_file_to_class_name(classdir, file) for file in get_class_files(javac_command)]

--- a/do_like_javac/tools/common.py
+++ b/do_like_javac/tools/common.py
@@ -19,6 +19,16 @@ def class_directory(javac_command):
       return switches['d']
   return None
 
+def get_classes(javac_command):
+  classes = []
+  classdir = class_directory(javac_command)
+
+  if classdir:
+    for root, dirs, files in os.walk(classdir):
+      classes.extend([file for file in files if '.class' in file])
+
+  return classes
+
 def source_path(javac_command):
   if 'javac_switches' in javac_command:
     switches = javac_command['javac_switches']

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -37,12 +37,12 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
   compile_classpath = os.path.join(lib_dir, "junit-4.12.jar") + ":" + base_classpath
   chicory_classpath = os.path.abspath(test_class_directory) + ":" + os.path.join(lib_dir, "daikon.jar") + ":" + os.path.join(lib_dir, "hamcrest-core-1.3.jar") + ":" + compile_classpath
 
-  classes = get_classes(classdir)
+  classes = sorted(common.get_classes(java_command))
 
   if 'randoop' in run_parts:
     class_list_file = make_class_list(classes)
-    time_limit = 10
-    output_limit = 20
+    time_limit = 300
+    output_limit = 30
 
     generate_tests(randoop_classpath, class_list_file, test_src_dir, time_limit, output_limit)
 
@@ -51,17 +51,34 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
     compile_test_cases(compile_classpath, test_class_directory, files_to_compile)
 
   if 'chicory' in run_parts:
-    run_chicory(chicory_classpath, randoop_driver, test_class_directory)
+    run_dyncomp(chicory_classpath, classdir, randoop_driver, test_class_directory)
+    run_chicory(chicory_classpath, classdir, randoop_driver, test_class_directory)
+    run_daikon(chicory_classpath, test_class_directory)
 
-def get_classes(classdir):
-  classes = []
+def get_select_list(classdir):
+  selects = []
+  last_add = " " # guaranteed not to match
   for root, dirs, files in os.walk(classdir):
-    for file in files:
-      if file.endswith('.class'):
-        classfile = os.path.join(root, file)
-        classname = classfile.replace(classdir + "/", '').replace('.class','').replace('/','.')
-        classes.append(classname)
-  return classes
+    if not root.startswith(last_add):
+      for file in files:
+        if file.endswith('.class'):
+          if root == classdir:
+            break
+          last_add = root
+          select = "--ppt-select-pattern=" + root.replace(classdir + "/", '').replace('/','.')
+          selects.append(select)
+          break
+  return selects
+
+def get_omit_list(omit_file_path, classdir):
+  omits = []
+
+  if os.path.isfile(omit_file_path):
+    with open(omit_file_path, 'r') as f:
+      for line in f:
+        omit = "--ppt-omit-pattern=" + line.strip()
+        omits.append(omit)
+  return omits
 
 def make_class_list(classes):
   with tempfile.NamedTemporaryFile('w', suffix='.txt', prefix='clist', delete=False) as class_file:
@@ -81,6 +98,10 @@ def generate_tests(randoop_classpath, class_list_file, test_src_dir, time_limit,
                      "--ignore-flaky-tests=true",
                      "--silently-ignore-bad-class-names=true",
                      '--junit-output-dir={}'.format(test_src_dir)]
+
+  junit_after_path = os.path.join(test_src_dir, "..", "junit-after-code")
+  if os.path.exists(junit_after_path):
+    randoop_command.append("--junit-after-all={}".format(junit_after_path))
 
   if output_limit and output_limit > 0:
     randoop_command.append('--outputlimit={}'.format(output_limit))
@@ -104,11 +125,47 @@ def compile_test_cases(compile_classpath, test_class_directory, files_to_compile
 
   common.run_cmd(compile_command)
 
-def run_chicory(chicory_classpath, main_class, out_dir):
+
+def run_chicory(chicory_classpath, classdir, main_class, out_dir):
+  selects = get_select_list(classdir)
+  omits = get_omit_list(os.path.join(out_dir, "..", "omit-list"), classdir)
   chicory_command = ["java",
                      "-classpath", chicory_classpath,
                      "daikon.Chicory",
-                     "--output_dir={}".format(out_dir),
-                     main_class]
+                     "--comparability-file={}/RegressionTestDriver.decls-DynComp".format(out_dir),
+                     "--output_dir={}".format(out_dir)]
+  for select in selects:
+    chicory_command.append(select)
+  for omit in omits:
+    chicory_command.append(omit)
+  chicory_command.append(main_class)
 
   common.run_cmd(chicory_command)
+
+
+def run_dyncomp(dyncomp_classpath, classdir, main_class, out_dir):
+  selects = get_select_list(classdir)
+  omits = get_omit_list(os.path.join(out_dir, "..", "omit-list"), classdir)
+  dyncomp_command = ["java",
+                     "-classpath", dyncomp_classpath,
+                     "daikon.DynComp",
+                     "--no-cset-file",
+                     "--output-dir={}".format(out_dir)]
+  for select in selects:
+    dyncomp_command.append(select)
+  for omit in omits:
+    dyncomp_command.append(omit)
+  dyncomp_command.append(main_class)
+
+  common.run_cmd(dyncomp_command)
+
+
+def run_daikon(daikon_classpath, out_dir):
+  daikon_command = ["java",
+                     "-classpath", daikon_classpath,
+                     "daikon.Daikon",
+                     "-o", out_dir+"/invariants.gz",
+                     out_dir+"/RegressionTestDriver.dtrace.gz"]
+
+  common.run_cmd(daikon_command)
+

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -20,7 +20,11 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
   test_src_dir = os.path.join(out_dir, "test-src{}".format(i))
   test_class_directory = os.path.join(out_dir, "test-classes{}".format(i))
 
-  base_classpath = classpath + ":" + classdir
+  if classpath:
+    base_classpath = classpath + ":" + classdir
+  else:
+    base_classpath = classdir
+
   randoop_classpath = base_classpath + ":" + os.path.join(lib_dir, "randoop.jar")
   compile_classpath = base_classpath + ":" + os.path.join(lib_dir, "junit-4.12.jar")
   chicory_classpath = compile_classpath + ":" + os.path.abspath(test_class_directory) + ":" + os.path.join(lib_dir, "daikon.jar") + ":" + os.path.join(lib_dir, "hamcrest-core-1.3.jar")

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -20,10 +20,16 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
   test_src_dir = os.path.join(out_dir, "test-src{}".format(i))
   test_class_directory = os.path.join(out_dir, "test-classes{}".format(i))
 
+  if not os.path.exists(test_class_directory):
+    os.mkdir(test_class_directory)
+
   if classpath:
     base_classpath = classpath + ":" + classdir
   else:
     base_classpath = classdir
+
+  with open(os.path.join(test_class_directory, 'classpath.txt'), 'w') as f:
+    f.write(base_classpath)
 
   randoop_classpath = base_classpath + ":" + os.path.join(lib_dir, "randoop.jar")
   compile_classpath = base_classpath + ":" + os.path.join(lib_dir, "junit-4.12.jar")
@@ -88,9 +94,6 @@ def get_files_to_compile(test_src_dir):
   return jfiles
 
 def compile_test_cases(compile_classpath, test_class_directory, files_to_compile):
-  if not os.path.exists(test_class_directory):
-    os.mkdir(test_class_directory)
-
   compile_command = ["javac", "-g",
                      "-classpath", compile_classpath,
                      "-d", test_class_directory]

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -43,7 +43,7 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
     compile_test_cases(compile_classpath, test_class_directory, files_to_compile)
 
   if 'chicory' in run_parts:
-    run_chicory(chicory_classpath, classes, randoop_driver, out_dir)
+    run_chicory(chicory_classpath, classes, randoop_driver, test_class_directory)
 
 def get_classes(classdir):
   classes = []

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -30,6 +30,8 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
 
   with open(os.path.join(test_class_directory, 'classpath.txt'), 'w') as f:
     f.write(base_classpath)
+  with open(os.path.join(test_class_directory, 'classdir.txt'), 'w') as f:
+    f.write(classdir)
 
   randoop_classpath = os.path.join(lib_dir, "randoop.jar") + ":" + base_classpath
   compile_classpath = os.path.join(lib_dir, "junit-4.12.jar") + ":" + base_classpath

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -43,7 +43,7 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
     compile_test_cases(compile_classpath, test_class_directory, files_to_compile)
 
   if 'chicory' in run_parts:
-    run_chicory(chicory_classpath, classes, randoop_driver, test_class_directory)
+    run_chicory(chicory_classpath, randoop_driver, test_class_directory)
 
 def get_classes(classdir):
   classes = []
@@ -98,7 +98,7 @@ def compile_test_cases(compile_classpath, test_class_directory, files_to_compile
 
   common.run_cmd(compile_command)
 
-def run_chicory(chicory_classpath, classes_to_include, main_class, out_dir):
+def run_chicory(chicory_classpath, main_class, out_dir):
   chicory_command = ["java",
                      "-classpath", chicory_classpath,
                      "daikon.Chicory",

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -1,24 +1,18 @@
 import os
-import argparse
 import common
 import tempfile
 
-argparser = argparse.ArgumentParser(add_help=False)
-dyntrace_group = argparser.add_argument_group('dyntrace arguments')
-
-dyntrace_group.add_argument("--dyntrace-libs", metavar='<dyntrace-lib-dir>',
-                            action='store', default=None, dest='dyn_lib_dir',
-                            help='Library directory with JARs for randoop, daikon, and junit.')
+argparser = None
 
 def run(args, javac_commands, jars):
   i = 1
   out_dir = os.path.basename(args.output_directory)
 
   for jc in javac_commands:
-    dyntrace(i, jc, out_dir, args.dyn_lib_dir)
+    dyntrace(i, jc, out_dir, args.lib_dir)
     i = i + 1
 
-def dyntrace(i, java_command, out_dir, lib_dir):
+def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory']):
   classpath = common.classpath(java_command)
   classdir = os.path.abspath(common.class_directory(java_command))
 
@@ -33,16 +27,19 @@ def dyntrace(i, java_command, out_dir, lib_dir):
 
   classes = get_classes(classdir)
 
-  class_list_file = make_class_list(classes)
-  time_limit = 10
-  output_limit = 20
+  if 'randoop' in run_parts:
+    class_list_file = make_class_list(classes)
+    time_limit = 10
+    output_limit = 20
 
-  generate_tests(randoop_classpath, class_list_file, test_src_dir, time_limit, output_limit)
+    generate_tests(randoop_classpath, class_list_file, test_src_dir, time_limit, output_limit)
 
-  files_to_compile = get_files_to_compile(test_src_dir)
+    files_to_compile = get_files_to_compile(test_src_dir)
 
-  compile_test_cases(compile_classpath, test_class_directory, files_to_compile)
-  run_chicory(chicory_classpath, classes, randoop_driver, out_dir)
+    compile_test_cases(compile_classpath, test_class_directory, files_to_compile)
+
+  if 'chicory' in run_parts:
+    run_chicory(chicory_classpath, classes, randoop_driver, out_dir)
 
 def get_classes(classdir):
   classes = []

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -78,6 +78,7 @@ def generate_tests(randoop_classpath, class_list_file, test_src_dir, time_limit,
                      '--classlist={}'.format(class_list_file),
                      "--timelimit={}".format(time_limit),
                      "--junit-reflection-allowed=false",
+                     "--ignore-flaky-tests=true",
                      "--silently-ignore-bad-class-names=true",
                      '--junit-output-dir={}'.format(test_src_dir)]
 

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -31,9 +31,9 @@ def dyntrace(i, java_command, out_dir, lib_dir, run_parts=['randoop','chicory'])
   with open(os.path.join(test_class_directory, 'classpath.txt'), 'w') as f:
     f.write(base_classpath)
 
-  randoop_classpath = base_classpath + ":" + os.path.join(lib_dir, "randoop.jar")
-  compile_classpath = base_classpath + ":" + os.path.join(lib_dir, "junit-4.12.jar")
-  chicory_classpath = compile_classpath + ":" + os.path.abspath(test_class_directory) + ":" + os.path.join(lib_dir, "daikon.jar") + ":" + os.path.join(lib_dir, "hamcrest-core-1.3.jar")
+  randoop_classpath = os.path.join(lib_dir, "randoop.jar") + ":" + base_classpath
+  compile_classpath = os.path.join(lib_dir, "junit-4.12.jar") + ":" + base_classpath
+  chicory_classpath = os.path.abspath(test_class_directory) + ":" + os.path.join(lib_dir, "daikon.jar") + ":" + os.path.join(lib_dir, "hamcrest-core-1.3.jar") + ":" + compile_classpath
 
   classes = get_classes(classdir)
 

--- a/do_like_javac/tools/graphtools.py
+++ b/do_like_javac/tools/graphtools.py
@@ -16,6 +16,10 @@ def run(args, javac_commands, jars):
 
   tool_command = ["java", "-jar", args.graph_jar]
 
+  dot_dir = os.path.join(args.output_directory, "dot")
+  if not os.path.isdir(dot_dir):
+    os.makedirs(dot_dir)
+
   for jc in javac_commands:
     java_files = jc['java_files']
     java_files_file = os.path.join(os.getcwd(), '__java_file_names.txt')
@@ -27,7 +31,7 @@ def run(args, javac_commands, jars):
         f.write(s)
         f.write("\n")
 
-    current_outdir = os.path.join(args.output_directory,
+    current_outdir = os.path.join(dot_dir,
                                   class_dir.replace(os.getcwd(),'').replace(os.sep,"_"))
 
     cmd = tool_command + ["-o", current_outdir,

--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -17,6 +17,9 @@ infer_group.add_argument('-m', '--mode', metavar='<mode>',
 infer_group.add_argument('-solverArgs', '--solverArgs', metavar='<solverArgs>',
                         action='store',default='backEndType=maxsatbackend.MaxSat',
                         help='arguments for solver')
+infer_group.add_argument('-cfArgs', '--cfArgs', metavar='<cfArgs>',
+                        action='store',default='',
+                        help='arguments for checker framework')
 
 def run(args, javac_commands, jars):
     # the dist directory if CFI.
@@ -33,9 +36,13 @@ def run(args, javac_commands, jars):
              ':' + os.path.join(CFI_dist, 'plume.jar') + \
              ':' + os.path.join(CFI_dist, 'checker-framework-inference.jar')
 
+        if 'CLASSPATH' in os.environ:
+            cp += ':' + os.environ['CLASSPATH']
+
         cmd = CFI_command + ['-classpath', cp,
                              'checkers.inference.InferenceLauncher',
                              '--solverArgs', args.solverArgs,
+                             '--cfArgs', args.cfArgs,
                              '--checker', args.checker,
                              '--solver', args.solver,
                              '--mode', args.mode,

--- a/do_like_javac/tools/randoop_old.py
+++ b/do_like_javac/tools/randoop_old.py
@@ -1,0 +1,129 @@
+import os
+import pprint
+import shutil
+import glob
+import urllib
+
+argparser = None
+
+def run(args, javac_commands, jars):
+    pp = pprint.PrettyPrinter(indent=2)
+    i = 0
+    for jc in javac_commands:
+        javac_switches = jc['javac_switches']
+        cp = javac_switches['classpath']
+        class_file_dir = javac_switches['d']
+        class_files = [y for x in os.walk(class_file_dir) for y in glob.glob(os.path.join(x[0], '*.class'))]
+
+        if len(class_files)==0:
+            continue
+
+        out_dir_name = "__randoop_%04d" % (i)
+        if not os.path.exists(out_dir_name):
+            os.makedirs(out_dir_name)
+
+        class_files_file_name = os.path.join(out_dir_name, 'class_files.txt')
+        print ("Creating list of files %d in %s." % (len(class_files), os.path.abspath(out_dir_name)) )
+        with open(class_files_file_name, mode='w') as myfile:
+            for class_file_name in class_files:
+                myfile.write(get_qualified_class_name_from_file(class_file_name, class_file_dir))
+                myfile.write(os.linesep)
+
+        (randoop_jar, junit_jar, hamcrest_jar) = find_or_download_jars()
+
+        cp_entries = cp.split(os.pathsep)
+        clean_cp = list()
+        clean_cp.append(randoop_jar)
+        clean_cp.append(class_file_dir)
+
+        lib_dir_name = "__randoop_libs"
+        if not os.path.exists(lib_dir_name):
+            os.makedirs(lib_dir_name)
+
+        for cp_entry in cp_entries:
+            if cp_entry.endswith(".jar"):
+                #check if the jar is in a sub directory of the project.
+                #if not copy it into a new subdirectory and add the
+                #corresponding classpath entry.
+                if not os.path.realpath(cp_entry).startswith(os.getcwd()):
+                    new_jar_name = os.path.join(lib_dir_name, os.path.basename(cp_entry))
+                    if not os.path.isfile(new_jar_name):
+                        shutil.copyfile(cp_entry, new_jar_name)
+                    clean_cp.append(new_jar_name)
+                else:
+                    clean_cp.append(cp_entry)
+                pass
+            else:
+                #todo what happens here?
+                clean_cp.append(cp_entry)
+
+        randoop_cmd = ['java', '-ea', '-classpath', os.pathsep.join(clean_cp), 
+                "randoop.main.Main", "gentests", "--classlist=%s"%class_files_file_name,
+                "--timelimit=60", "--silently-ignore-bad-class-names=true",
+                "--junit-output-dir=%s"%out_dir_name]
+
+        junit_cp = list(clean_cp)
+        junit_cp.append(junit_jar)
+        junit_build_cmd = ['javac', '-classpath', os.pathsep.join(junit_cp), os.path.join(out_dir_name, 'RandoopTest*.java'), '-d', out_dir_name]
+
+        junit_run_cp = list(junit_cp)
+        junit_run_cp.append(hamcrest_jar)
+        junit_run_cp.append(out_dir_name)
+
+        junit_run_cmd = ['java', '-classpath', os.pathsep.join(junit_run_cp), "org.junit.runner.JUnitCore", 'RandoopTest']
+
+        bash_script_name = "run_randoop_%04d.sh" % (i)
+        with open(bash_script_name, mode='w') as myfile:
+            myfile.write("#!/bin/bash\n")
+            myfile.write("echo \"Run Randoop\"\n")
+            myfile.write(" ".join(randoop_cmd))
+            myfile.write("\n")
+            myfile.write("echo \"Build tests\"\n")
+            myfile.write(" ".join(junit_build_cmd))
+            myfile.write("\n")
+            myfile.write("echo \"Run tests\"\n")
+            myfile.write(" ".join(junit_run_cmd))
+            myfile.write("\n")
+        print ("Written script to %s" % bash_script_name)
+
+        i += 1
+
+def get_qualified_class_name_from_file(class_file_name, class_file_path):
+    """ terrible hack for now """
+    suffix = class_file_name.replace(class_file_path+os.sep, "")
+    mid_section = suffix.replace(".class", "")
+    return mid_section.replace(os.sep, ".")
+
+
+def find_or_download_jars():
+    '''
+        Finds or downloads the randoop, junit, and hamrest jars.
+    '''
+    randoop_jar_dir = os.path.join(os.getcwd(), '__randoop_files')
+    if not os.path.isdir(randoop_jar_dir):
+        os.makedirs(randoop_jar_dir)
+
+    randoop_jar = os.path.join(randoop_jar_dir, "randoop-2.0.jar")
+    if not os.path.isfile(randoop_jar):
+        print("Downloading randoop to %s" % randoop_jar )
+        urllib.urlretrieve ("https://github.com/randoop/randoop/releases/download/v2.0/randoop-2.0.jar", randoop_jar)
+
+    junit_jar = os.path.join(randoop_jar_dir, "junit-4.12.jar")
+    if not os.path.isfile(junit_jar):
+        print("Downloading junit to %s" % junit_jar )
+        urllib.urlretrieve ("https://github.com/junit-team/junit/releases/download/r4.12/junit-4.12.jar", junit_jar)
+
+    hamcrest_jar = os.path.join(randoop_jar_dir, "hamcrest-core-1.3.jar")
+    if not os.path.isfile(hamcrest_jar):
+        print("Downloading hamcrest to %s" % hamcrest_jar )
+        urllib.urlretrieve ("http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar", hamcrest_jar)
+
+    return (randoop_jar, junit_jar, hamcrest_jar)
+
+
+
+
+
+
+
+


### PR DESCRIPTION
- Split Dyntrace into separate parts for randoop and daikon
- Support omit lists and junit-after arguments in dyntrace
- Contain graphtools dot output in "dot" subdirectory of dljc-out
- Add statistics recording