### PR TITLE
make CF Inference only output WARN and SEVERE log.

### DIFF
--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -48,6 +48,7 @@ def run(args, javac_commands, jars):
                              '--mode', args.mode,
                              '--hacks=true',
                              '--targetclasspath', target_cp,
+                             '--logLevel=WARNING',
                              '-afud', args.afuOutputDir]
         cmd.extend(jc['java_files'])
 


### PR DESCRIPTION
Reduce the debug output from CF Inference.