### PR TITLE
Double Randoop output limit

### DIFF
--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -97,7 +97,7 @@ def make_class_list(out_dir, classes):
     class_file.flush()
     return class_file.name
 
-def generate_tests(classpath, class_list_file, test_src_dir, time_limit=60, output_limit=2000):
+def generate_tests(classpath, class_list_file, test_src_dir, time_limit=60, output_limit=4000):
   randoop_command = ["java", "-ea",
                      "-classpath", classpath,
                      "randoop.main.Main", "gentests",


### PR DESCRIPTION
Increases Randoop output limit from 2000 to 4000. 