### PR TITLE
Dyntrace updates

### DIFF
--- a/do_like_javac/tools/__init__.py
+++ b/do_like_javac/tools/__init__.py
@@ -5,6 +5,7 @@ import bixie
 import graphtools
 import chicory
 import dyntrace
+import dyntracecounts
 
 # import soot
 import check
@@ -21,6 +22,7 @@ TOOLS = {
   'graphtool' : graphtools,
   'chicory'   : chicory,
   'dyntrace'  : dyntrace,
+  'dyntracecounts' : dyntracecounts,
 }
 
 def parsers():

--- a/do_like_javac/tools/common.py
+++ b/do_like_javac/tools/common.py
@@ -1,4 +1,3 @@
-import time
 import sys, os, traceback
 import subprocess32 as subprocess
 from threading import Timer
@@ -57,10 +56,7 @@ def run_cmd(cmd, print_output=True, timeout=None):
   timer = None
 
   if print_output:
-    print time.strftime('%X %x')
     print ("Running %s" % ' '.join(cmd))
-    # force immediate output to help with debugging
-    sys.stdout.flush()
   try:
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/do_like_javac/tools/common.py
+++ b/do_like_javac/tools/common.py
@@ -2,6 +2,7 @@ import sys
 import subprocess
 import traceback
 import os
+import time
 
 def classpath(javac_command):
   if 'javac_switches' in javac_command:
@@ -46,7 +47,10 @@ def source_path(javac_command):
   return None
 
 def run_cmd(cmd):
+  print time.strftime('%X %x')
   print "Running {}".format(' '.join(cmd))
+  # force immediate output to help with debugging
+  sys.stdout.flush()
   try:
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     for line in iter(process.stdout.readline, b''):

--- a/do_like_javac/tools/dyntracecounts.py
+++ b/do_like_javac/tools/dyntracecounts.py
@@ -1,0 +1,12 @@
+import os
+import dyntrace
+
+argparser = None
+
+def run(args, javac_commands, jars):
+  i = 1
+  out_dir = os.path.basename(args.output_directory)
+
+  for jc in javac_commands:
+    dyntrace.dyntrace(args, i, jc, out_dir, args.lib_dir, ['randoop', 'chicory', 'invcounts'])
+    i = i + 1


### PR DESCRIPTION
Several combined updates to dyntrace.py:
- increase Java heap size for tools
- support for NO-TERNARY in omit-list files
- add dyntracecounts.py tool to run daikon twice; once normally, then again getting total invariant count

IMPORTANT: This merge must be done before similarly named pull request in aas-integration/integration-test2.