### PR TITLE
updates to dyntrace.py

### DIFF
--- a/do_like_javac/tools/common.py
+++ b/do_like_javac/tools/common.py
@@ -1,4 +1,3 @@
-import time
 import sys, os, traceback
 import subprocess32 as subprocess
 from threading import Timer
@@ -57,10 +56,7 @@ def run_cmd(cmd, print_output=True, timeout=None):
   timer = None
 
   if print_output:
-    print time.strftime('%X %x')
     print ("Running %s" % ' '.join(cmd))
-    # force immediate output to help with debugging
-    sys.stdout.flush()
   try:
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/do_like_javac/tools/dyntrace.py
+++ b/do_like_javac/tools/dyntrace.py
@@ -118,7 +118,7 @@ def make_class_list(out_dir, classes):
     class_file.flush()
     return class_file.name
 
-def generate_tests(args, classpath, class_list_file, test_src_dir, junit_after_path, time_limit=60, output_limit=4000):
+def generate_tests(args, classpath, class_list_file, test_src_dir, junit_after_path, time_limit=200, output_limit=4000):
   randoop_command = ["java", "-ea",
                      "-classpath", classpath,
                      "randoop.main.Main", "gentests",
@@ -126,6 +126,7 @@ def generate_tests(args, classpath, class_list_file, test_src_dir, junit_after_p
                      "--timelimit={}".format(time_limit),
                      "--junit-reflection-allowed=false",
                      "--ignore-flaky-tests=true",
+                     "--timeout=5",
                      "--silently-ignore-bad-class-names=true",
                      '--junit-output-dir={}'.format(test_src_dir)]
 


### PR DESCRIPTION
Increase time_limit value to randoop to allow more time to generate test cases.

Add a '--timeout' argument to randoop to keep it from generating tests that will take too long to execute under DynComp.
 